### PR TITLE
Fix command name for `chrome-webstore-upload` plugin

### DIFF
--- a/src/chrome-webstore/commands/publish.yml
+++ b/src/chrome-webstore/commands/publish.yml
@@ -26,7 +26,7 @@ steps:
   - run:
       name: Publish A Extension
       command: |
-        $(npm bin)/webstore publish \
+        $(npm bin)/chrome-webstore-upload publish \
           --extension-id << parameters.extension-id >> \
           --client-id ${<< parameters.client-id >>} \
           --client-secret ${<< parameters.client-secret >>} \

--- a/src/chrome-webstore/commands/upload.yml
+++ b/src/chrome-webstore/commands/upload.yml
@@ -29,7 +29,7 @@ steps:
   - run:
       name: Upload A Extension
       command: |
-        $(npm bin)/webstore upload \
+        $(npm bin)/chrome-webstore-upload upload \
           --source << parameters.source >> \
           --extension-id << parameters.extension-id >> \
           --client-id ${<< parameters.client-id >>} \


### PR DESCRIPTION
It seems that the name for the utility has changed, so it need to be called with `chrome-webstore-upload` rather than just `webstore`